### PR TITLE
isolate effect runners

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1,6 +1,5 @@
 module Lib where
 
-import Data.Maybe
 import GHC.Natural
 import System.IO
 import Text.Read


### PR DESCRIPTION
Isolate lifting and running of effects. Program is obtained by lifting to a tower (ie, monadic stack) of effects (ie, IO, Maybe/Either/Validate, List, FizzBuzz DSL) and then pile the bananas / detonate the effects only very close to the edge of the application (interpret / render DSL, run list, run option, run IO) to not break composability. In this case, it allows to have almost the entire program testable as a pure function NOT in the IO context 